### PR TITLE
Adding provenance to Time and Unit entities

### DIFF
--- a/arborist/__init__.py
+++ b/arborist/__init__.py
@@ -12,7 +12,7 @@ __all__ = (
     "get_metadata",
     "generate_provenance_uris"
 )
-VERSION = (0, 4)
+VERSION = (0, 5)
 __version__ = ".".join(str(v) for v in VERSION)
 
 data_dir = "data"

--- a/arborist/provenance_uris.py
+++ b/arborist/provenance_uris.py
@@ -58,7 +58,6 @@ def generate_provenance_uris(output_base_dir):
             ),
         )
     )
-    today = datetime.datetime.now().strftime("%Y-%m-%d")
     g.add((ebd, OWL.versionInfo, Literal("3.3.17")))
     g.add((ebd, DC.term("license"), URIRef("https://www.exiobase.eu/index.php/terms-of-use")))
     g.add((ebd, DC.term("date"), Literal(exiobase_update_date, datatype=XSD.date)))

--- a/arborist/time_uris.py
+++ b/arborist/time_uris.py
@@ -341,7 +341,10 @@ def generate_time_uris(output_base_dir):
     )
 
     BRDFTIME = Namespace("http://rdf.bonsai.uno/time#")
+    PROV = Namespace("http://www.w3.org/ns/prov#")
+    time_node = URIRef("http://rdf.bonsai.uno/time")
     g.bind("brdftime", BRDFTIME)
+    g.bind("prov", PROV)
 
     oneyear = BRDFTIME.oneyearlong
     g.add((oneyear, RDF.type, owltime.DurationDescription))
@@ -389,6 +392,9 @@ def generate_time_uris(output_base_dir):
                 URIRef("http://reference.data.gov.uk/doc/year/{}".format(year)),
             )
         )
+
+        # Adding Provenance
+        g.add((time_node, PROV.hadMember, node))
 
     for period in time_periods:
         start, end = period.split("-")

--- a/arborist/unit_uris.py
+++ b/arborist/unit_uris.py
@@ -1,7 +1,7 @@
 from .filesystem import write_graph
 from .graph_common import add_common_elements
 from pathlib import Path
-from rdflib import Graph, Literal, RDF, URIRef
+from rdflib import Graph, Literal, RDF, URIRef, Namespace
 from rdflib.namespace import RDFS
 
 
@@ -75,11 +75,18 @@ def generate_unit_uris(output_base_dir):
         description="Units from ontology-of-units-of-measure used in BONSAI",
         author="Chris Mutel"
     )
+
+    unit_node = URIRef("http://rdf.bonsai.uno/unit")
+    PROV = Namespace("http://www.w3.org/ns/prov#")
+    g.bind("prov", PROV)
     g.bind("om2", "http://www.ontology-of-units-of-measure.org/resource/om-2/")
 
     for label, uri, kind in units:
         node = URIRef(uri)
         g.add((node, RDF.type, URIRef(kind)))
         g.add((node, RDFS.label, Literal(label)))
+
+        # Add Provenance
+        g.add((unit_node, PROV.hadMember, node))
 
     write_graph(output_base_dir / "unit", g)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def package_files(directory):
 
 setup(
     name='arborist',
-    version="0.4",
+    version="0.5",
     packages=find_packages(),
     author="BONSAI team",
     author_email="info@bonsai.uno",


### PR DESCRIPTION
This pull request adds provenance to `time` and `unit` uris.
We are about to change the extraction of Exiobase triples to adhere to the new Ontology v0.2, so in order to keep provenance for the new version of the `EXIOBASE-conversion-software`, we also change the version of this script from v0.4 to v0.5.  
