### PR TITLE
Adding provenance various places it is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ output
 
 #### Emission flows
 The library can also be used to extract emission flows from the exiobase extension table.
-To do this, first download and insert `MR_HSUT_2011_v3_3_17_extensions.xlsb` into the /data folder, then set `"extract_exiobase_emissions": true` in `config.json`.
+To do this, first download `MR_HSUT_2011_v3_3_17_extensions.xlsb` into a input/ folder, then set `"extract_exiobase_emissions": true` in `config.json`.
 The exiobase extensions table can be downloaded from this url: [www.exiobase.eu](https://www.exiobase.eu/).
 
+Using the cli tool to extract emissions can be done from the terminal with the `-i input/dir` argument, such as:
+`arborist-cli regenerate output -i input/`.
 
 #### Configuration
 The package provides a `Config.json` file which enables the user to choose what graphs to extract. 

--- a/arborist/__init__.py
+++ b/arborist/__init__.py
@@ -1,6 +1,5 @@
 import os
 import json
-import pkg_resources
 from pathlib import Path
 
 __all__ = (
@@ -37,7 +36,7 @@ from .provenance_uris import generate_provenance_uris
 from .extract_emissions import generate_emissions
 
 
-def generate_all(base_dir):
+def generate_all(base_dir, input_dir):
     config_name = "config.json"
     config_path = Path(config_name)
     if not os.path.exists(config_path):
@@ -47,8 +46,9 @@ def generate_all(base_dir):
     with open(config_name) as json_file:
         options = json.load(json_file)
 
-        if options['extract_exiobase_emissions'] is True:
-            generate_emissions(base_dir)
+        if input_dir:
+            if options['extract_exiobase_emissions'] is True:
+                generate_emissions(base_dir, input_dir)
 
         if options["extract_climate_change"] is True:
             generate_climate_change_uris(base_dir)

--- a/arborist/bin/arborist_cli.py
+++ b/arborist/bin/arborist_cli.py
@@ -4,6 +4,7 @@
 
 Usage:
   arborist-cli regenerate <dirpath>
+  arborist-cli regenerate <dirpath> -i <input>
 
 Options:
   -h --help     Show this screen.
@@ -18,7 +19,7 @@ import sys
 def main():
     try:
         args = docopt(__doc__, version="0.2")
-        generate_all(args["<dirpath>"])
+        generate_all(args["<dirpath>"], args["<input>"])
     except KeyboardInterrupt:
         print("Terminating CLI")
         sys.exit(1)

--- a/arborist/extract_emissions.py
+++ b/arborist/extract_emissions.py
@@ -28,7 +28,7 @@ def setup_empty_graph():
     BRDFLO = Namespace("http://rdf.bonsai.uno/location/exiobase3_3_17#")
     BRDFTIME = Namespace("http://rdf.bonsai.uno/time#")
     BRDFFAT = Namespace("http://rdf.bonsai.uno/activitytype/exiobase3_3_17#")
-    BRDFFOAF = Namespace("http://rdf.bonsai.uno/foaf/exiobase3_3_17#")
+    BRDFFOAF = Namespace("http://rdf.bonsai.uno/foaf/bonsai#")
     BRDFDAT = Namespace("http://rdf.bonsai.uno/data/exiobase3_3_17/emission#")
     BRDFPROV = Namespace("http://rdf.bonsai.uno/prov/exiobase3_3_17#")
     CC = Namespace('http://creativecommons.org/ns#')
@@ -61,7 +61,7 @@ def setup_empty_graph():
     g.bind("brdffat", BRDFFAT)
     g.bind("brdfdat", BRDFDAT)
     g.bind("brdfprov", BRDFPROV)
-    g.bind("brdffoaf", BRDFFOAF)
+    g.bind("bfoaf", BRDFFOAF)
     g.bind("cc", CC)
     g.bind("dc", DC)
     g.bind("dtype", DTYPE)
@@ -77,19 +77,18 @@ def setup_empty_graph():
     return g
 
 
-def emissions(base_dir, sheetnum = 6):
+def emissions(base_dir, input_dir, sheetnum = 6):
     csvArr = []
     output_base_dir = Path(base_dir)
 
     xlsb = "MR_HSUT_2011_v3_3_17_extensions.xlsb"
-    if not os.path.exists(Path(data_dir, xlsb)):
-        print("Please add file {} to directory {}".format(xlsb, data_dir))
+    print(Path(input_dir, xlsb))
+    if not os.path.exists(Path(input_dir, xlsb)):
+        print("Please add file {} to directory {}".format(xlsb, input_dir))
         exit(0)
 
-    file_path = os.path.join(data_dir, xlsb)
-    file_handler = pkg_resources.resource_stream(__name__, file_path)
-
-    with open_xlsb(file_handler) as wb:
+    file_path = os.path.join(input_dir, xlsb)
+    with open_xlsb(file_path) as wb:
         # Read the sheet to array first and convert to pandas first for quick access
         with wb.get_sheet(sheetnum) as sheet:
             for row in sheet.rows(sparse=True):
@@ -100,7 +99,7 @@ def emissions(base_dir, sheetnum = 6):
 
     # Get emission codes from exiobase classifications
     extensions = "exiobase_classifications_v_3_3_17.xlsx"
-    if not os.path.exists(Path(data_dir, extensions)):
+    if not os.path.exists(Path("arborist/data", extensions)):
         print("Please add file {} to directory {}".format(extensions, data_dir))
         exit(0)
 
@@ -184,5 +183,5 @@ def emissions(base_dir, sheetnum = 6):
     write_graph(output_base_dir / "flow" / "exiobase3_3_17" / "emission", g)
 
 
-def generate_emissions(base_dir):
-    emissions(base_dir)
+def generate_emissions(base_dir, input_dir):
+    emissions(base_dir, input_dir)

--- a/arborist/foaf.py
+++ b/arborist/foaf.py
@@ -25,7 +25,7 @@ def generate_foaf_uris(output_base_dir):
     g.bind("dtype", dtype)
     g.bind("skos", SKOS)
     g.bind("foaf", FOAF)
-    g.bind("bonsaiprov", bfoaf_b)
+    g.bind("bonsaifoaf", bfoaf_b)
     g.bind("dc", DC)
     g.bind("bprov", bprov)
     g.bind("owl", OWL)
@@ -99,12 +99,12 @@ def generate_foaf_uris(output_base_dir):
     g.add((ec, FOAF.homepage, URIRef("https://www.exiobase.eu/")))
 
     # Provenance
-    b.add((node_b, prov.hadMember, node))
+    b.add((node_b, prov.hadMember, bonsai))
     g.add((node, prov.hadMember, ec))
 
     # Provenance
     b.add((node_b, RDF.type, prov.Collection))
-    b.add((node_b, prov.wasAttributedTo, bfoaf.bonsai))
+    b.add((node_b, prov.wasAttributedTo, bfoaf_b.bonsai))
     b.add((node_b, prov.wasGeneratedBy, bprov["dataExtractionActivity_{}".format(__version__.replace(".", "_"))]))
     b.add((node_b, prov.generatedAtTime, Literal(today, datatype=XSD.date)))
     b.add(
@@ -117,7 +117,7 @@ def generate_foaf_uris(output_base_dir):
 
     # Provenance
     g.add((node, RDF.type, prov.Collection))
-    g.add((node, prov.wasAttributedTo, bfoaf.bonsai))
+    g.add((node, prov.wasAttributedTo, bfoaf_b.bonsai))
     g.add((node, prov.wasGeneratedBy, bprov["dataExtractionActivity_{}".format(__version__.replace(".", "_"))]))
     g.add((node, prov.generatedAtTime, Literal(today, datatype=XSD.date)))
     g.add(

--- a/arborist/provenance_uris.py
+++ b/arborist/provenance_uris.py
@@ -14,6 +14,7 @@ def generate_provenance_uris(output_base_dir):
     prov = Namespace("http://www.w3.org/ns/prov#")
     purl = Namespace("http://purl.org/dc/dcmitype/")
     bfoaf = Namespace("http://rdf.bonsai.uno/foaf/exiobase3_3_17#")
+    bonsaifoaf = Namespace("http://rdf.bonsai.uno/foaf/bonsai#")
     bprov = Namespace("{}#".format(bprov_uri))
     dtype = Namespace("http://purl.org/dc/dcmitype/")
     vann = Namespace("http://purl.org/vocab/vann/")
@@ -28,6 +29,7 @@ def generate_provenance_uris(output_base_dir):
     g.bind("rdfs", RDFS)
     g.bind("prov", prov)
     g.bind("bfoaf", bfoaf)
+    g.bind("bonsaifoaf", bonsaifoaf)
     g.bind("bprov", bprov)
     g.bind("vann", vann)
 
@@ -35,13 +37,12 @@ def generate_provenance_uris(output_base_dir):
     node = URIRef(bprov_uri)
     today = datetime.datetime.now().strftime("%Y-%m-%d")
     g.add((node, RDF.type, dtype.Dataset))
-    g.add((node, DC.contributor, Literal("BONSAI team")))
     g.add((node, DC.description, Literal("Provenance information about datasets and data extraction activities")))
     g.add((node, vann.preferredNamespaceUri, URIRef(bprov)))
-    g.add((node, DC.creator, bfoaf.bonsai))
+    g.add((node, DC.creator, bonsaifoaf.bonsai))
     g.add((node, DC.license, URIRef("https://creativecommons.org/licenses/by/3.0/")))
     g.add((node, DC.modified, Literal(today, datatype=XSD.date)))
-    g.add((node, DC.publisher, Literal("bonsai.uno")))
+    g.add((node, DC.publisher, bonsaifoaf.bonsai))
     g.add((node, DC.title, Literal("Provenance information")))
     g.add((node, OWL.versionInfo, Literal(__version__)))
 
@@ -80,7 +81,7 @@ def generate_provenance_uris(output_base_dir):
     g.add((arborist_uri, prov.used, URIRef("http://ontology.bonsai.uno/core")))
     g.add((arborist_uri, prov.used, bprov["exiobaseDataset_{}".format(exiobase_version)]))
     g.add((arborist_uri, prov.hadPlan, URIRef(bprov.extractionScript)))
-    g.add((arborist_uri, prov.wasAssociatedWith, URIRef(bfoaf.bonsai)))
+    g.add((arborist_uri, prov.wasAssociatedWith, URIRef(bonsaifoaf.bonsai)))
     g.add((arborist_uri, OWL.versionInfo, Literal(__version__)))
 
     plan = URIRef(bprov.extractionScript)
@@ -88,5 +89,18 @@ def generate_provenance_uris(output_base_dir):
     g.add((plan, RDF.type, prov.Entity))
     g.add((plan, RDFS.label, Literal("Entity representing the latest version of the Arborist Script")))
     g.add((plan, prov.hadPrimarySource, URIRef("https://github.com/BONSAMURAIS/arborist/tree/v{}".format(__version__.replace(".", "_")))))
+
+    # Provenance
+    g.add((node, RDF.type, prov.Collection))
+    g.add((node, prov.wasAttributedTo, bonsaifoaf.bonsai))
+    g.add((node, prov.wasGeneratedBy, bprov["dataExtractionActivity_{}".format(__version__.replace(".", "_"))]))
+    g.add((node, prov.generatedAtTime, Literal(today, datatype=XSD.date)))
+    g.add(
+        (
+            node,
+            URIRef("http://creativecommons.org/ns#license"),
+            URIRef("http://creativecommons.org/licenses/by/3.0/"),
+        )
+    )
 
     write_graph(Path(output_base_dir) / "prov" / "exiobase3_3_17", g)


### PR DESCRIPTION
The reason for this pull request, is to enhance the way provenance is used for foaf and prov files.
In multiple files general hadMember provenance was not implemented, and due to the change in filestructure, [See This](bc95fe4), some prov relations to foaf elements were wrong.

Furthermore the cli now takes an `-i <input/dir>` argument, to enhance user experience. The README reflects this change.

